### PR TITLE
Exclude colorado_era5_anomaly notebook from runs

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -9,6 +9,8 @@ copyright: "2024"
 execute:
   # To execute notebooks via a Binder instead, replace 'cache' with 'binder'
   execute_notebooks: cache
+  exclude_patterns:
+    - '*colorado_era5*'
   timeout: 600
   allow_errors: False # cells with expected failures must set the `raises-exception` cell tag
 

--- a/notebooks/notebook-template.ipynb
+++ b/notebooks/notebook-template.ipynb
@@ -307,7 +307,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.10.12"
   },
   "nbdime-conflicts": {
    "local_diff": [


### PR DESCRIPTION
Updated config.yaml to exclude the era5 notebook from running automatically